### PR TITLE
feat: Convert `null` prop type to `any`

### DIFF
--- a/convert.ts
+++ b/convert.ts
@@ -58,6 +58,9 @@ const propValueToType = (key: string, propValue: any): TSTypeKind => {
     }
     throw new Error(`Cannot convert prop(${key}) constructor to type: ${propValue.name}`)
   }
+  if (types.namedTypes.NullLiteral.check(propValue)) {
+    return b.tsAnyKeyword()
+  }
   throw new Error(`Cannot convert prop(${key}) to type: ${propValue}`)
 }
 

--- a/convert.ts
+++ b/convert.ts
@@ -55,6 +55,7 @@ const propValueToType = (key: string, propValue: any): TSTypeKind => {
     case 'Date': return b.tsTypeReference(b.identifier('Date'))
     case 'Function': return b.tsTypeReference(b.identifier('Function'))
     case 'Symbol': return b.tsSymbolKeyword()
+    case 'undefined': return b.tsAnyKeyword()
     }
     throw new Error(`Cannot convert prop(${key}) constructor to type: ${propValue.name}`)
   }


### PR DESCRIPTION
Hi. I ran into an error with this expression. I believe it can be treated as `any`.
- `foo: { type: null }` => `foo: any`

ref: https://vuejs.org/guide/components/props.html#prop-validation