### PR TITLE
feat: Convert object method in return block

### DIFF
--- a/convert.ts
+++ b/convert.ts
@@ -350,7 +350,7 @@ const convertObjectMethodToFunctionDeclaration = (ident: string, objectMethod: t
     generator: objectMethod.generator,
     loc: objectMethod.loc,
     rest: objectMethod.rest ?? null,
-    returnType: objectMethod.returnType,
+    returnType: objectMethod.returnType ?? null,
     typeParameters: objectMethod.typeParameters ?? null,
   })
 }


### PR DESCRIPTION
- [fix: Detect props from return block of setup function](https://github.com/sapphi-red/vue-convert-to-script-setup-from-composition-api/commit/c71cd9477412aefdeb06f2abb0a72d31fbee0382)
- [feat: Convert object method in return block](https://github.com/sapphi-red/vue-convert-to-script-setup-from-composition-api/commit/8a90ed5726385dfb2aa7b2804942d0056c7433b6)

I don't think this converting is perfect, but it would work well in most projects.
```
return {
  async jumbo(v: number): Promise<number> {
    await $nextTick()
    emit('update:model-value', v)
    return 1
  },
}
```
=>
```
async function jumbo(v: number): Promise<number> {
  await $nextTick()
  emit('update:model-value', v)
  return 1
}
```